### PR TITLE
Refactor to split app into pages for easier state management

### DIFF
--- a/examples/dim-ice-app/api/api.ts
+++ b/examples/dim-ice-app/api/api.ts
@@ -25,8 +25,6 @@ async function fetchTootsFromUrl(
   // Assume they always exist
   const links = parsePaginationLins(linkHeader!);
 
-  console.debug("Link 🔗 header", links);
-
   //TODO response code error handling
   return { links, toots: (await response.json()) as Status[] };
 }

--- a/examples/dim-ice-app/api/models/getHomeTimelineResponse.ts
+++ b/examples/dim-ice-app/api/models/getHomeTimelineResponse.ts
@@ -12,7 +12,6 @@ export function parsePaginationLins(link: string): PaginationUrls {
         const trimmed = split.trim();
         // either <url> or rel="something"
         const dataStart = trimmed[0] === "<" ? 1 : 5;
-        console.debug({ trimmed });
         return trimmed.substring(dataStart, trimmed.length - 1);
       })
     )

--- a/examples/dim-ice-app/api/models/oauth/accessTokenResponse.ts
+++ b/examples/dim-ice-app/api/models/oauth/accessTokenResponse.ts
@@ -1,4 +1,4 @@
-import { AccessToken } from "../../string";
+import { AccessToken } from "../string";
 
 type Scope = string;
 type UnixTimestampInSeconds = number;
@@ -6,7 +6,7 @@ type AccessTokenResponse = {
   access_token: AccessToken;
   token_type: "Bearer";
   scope: Scope;
-  create_at: UnixTimestampInSeconds;
+  created_at: UnixTimestampInSeconds;
 };
 
 export default AccessTokenResponse;

--- a/examples/dim-ice-app/dimIceApp.ts
+++ b/examples/dim-ice-app/dimIceApp.ts
@@ -1,48 +1,21 @@
 // The dim ice app mastodon client root component
 import command from "../../src/elmish/command";
 import { type Command, type Dispatch } from "../../src/elmish/command";
-import { TemplateResult, html, nothing } from "lit-html";
+import { TemplateResult } from "lit-html";
 import ElmishElement from "../../src/elmishComponent";
-import Status from "./api/models/status";
 import { StatusCard } from "./components/statusCard";
 import { css } from "./styling";
 import MediaAttachmentCollection from "./components/mediaAttachment";
 import "@lit-labs/virtualizer";
-import { AccessToken } from "./api/models/string";
-import Application from "./api/models/apps/application";
-import AccessTokenResponse from "./api/models/oauth/accessTokenResponse";
-import {
-  tryLoadAppCredentials,
-  tryLoadAccessToken,
-  saveAppCredentials,
-  saveAccessToken,
-} from "./localStorage";
-import GetHomeTimelineResponse from "./api/models/getHomeTimelineResponse";
-import PaginationUrls from "./api/paginationUrls";
-import api from "./api/api";
 import homeTimelinePage, {
   HomeTimelinePageMessage,
   HomeTimelinePageModel,
 } from "./pages/homeTimelinePage";
-import { WelcomePageMessage, WelcomePageModel } from "./pages/welcomePage";
+import welcomePage, {
+  WelcomePageMessage,
+  WelcomePageModel,
+} from "./pages/welcomePage";
 import Instance from "./instance";
-
-/**
- * Represents the state when the app has an access token and is fetching the timeline
- */
-type LoadingTimeline = {
-  readonly type: "loadingTimeline";
-};
-
-/**
- * Represents the app state when on the home timeline "page" and the latest stati were loaded
- */
-type HomeTimeline = {
-  readonly type: "homeTimeline";
-  readonly toots: Status[];
-  readonly links: PaginationUrls;
-  readonly isLoadingMoreToots: boolean;
-};
 
 type Page =
   | {
@@ -53,57 +26,12 @@ type Page =
 /**
  *  App model represents the different states the app can be in
  */
-// type AppModel = (Unauthorized | Authorized) &
-//   StaticAppData & {
-//     page: "home timeline";
-//     pageModel: HomeTimelinePageModel;
-//   };
 type AppModel = {
-  currentPage: Page;
+  activePage: Page;
   instance: Instance;
 };
-export type AppMessage =
-  | {
-      readonly type: "set instance";
-      readonly instance: string;
-    }
-  | {
-      readonly type: "create app";
-    }
-  | {
-      readonly type: "set app credentials";
-      readonly app: Application;
-    }
-  | {
-      readonly type: "navigate to authorization page";
-    }
-  | {
-      // When the access token is loaded and needs to be verified
-      // If not valid then we need to reauthorize
-      readonly type: "verify credentials";
-      readonly accessToken: AccessToken;
-    }
-  | {
-      readonly type: "setAccessToken";
-      readonly token: AccessTokenResponse;
-    }
-  | {
-      readonly type: "load home timeline";
-      readonly token: AccessToken;
-    }
-  | {
-      readonly type: "set toots";
-      readonly homeTimeline: GetHomeTimelineResponse;
-    }
-  | {
-      readonly type: "append toots";
-      readonly toots: GetHomeTimelineResponse;
-    }
 
-  // New messages
-  | {
-      readonly type: "navigate to home timeline";
-    }
+export type AppMessage =
   | {
       readonly type: "welcome page message";
       readonly message: WelcomePageMessage;
@@ -113,108 +41,31 @@ export type AppMessage =
       readonly message: HomeTimelinePageMessage;
     };
 
-function startCodeExchange(
-  instance: Instance,
-  app: Application
-): [AppModel, Command<AppMessage>] {
-  // Get code from url
-  const currentLocation = new URL(location.href);
-  const code = currentLocation.searchParams.get("code");
-  // Remove code from url so we don't trigger another exchange accidentally
-  currentLocation.searchParams.delete("code");
-  // Reset path
-  currentLocation.pathname = "";
+function welcomePageMessage(message: WelcomePageMessage): AppMessage {
+  return { type: "welcome page message", message };
+}
 
-  //TODO consider moving side effects into commands
-  //TODO use new navigation api in chromium and fallback to old and crufty history
-  history.replaceState({}, "", currentLocation.href);
-  if (code === null) {
-    // This is an error. We got navigated to redirect but did not get a code passed as query parameter
-    // Though this is an expectable error as users can just open the app with "/redirect"
-    // and very likely don't pass a valid authorization code in the query
-    // There are many other reasons we can end up in this stateW
-
-    return [
-      {
-        type: "firstOpen",
-        error: "noCodeRedirect",
-        instance,
-      },
-      command.none,
-    ];
-  }
-
-  // Start async code exchange command (side effect)
-  //TODO develop alternative functions that use function.apply with an arguments array.
-  //TODO error handling
-  // I just need to find out how to type this in TS
-  // That way I can shorten the signature maybe, is this good?
-  const exchangeCommand = command.ofPromise.perform(
-    ({ base, code }) =>
-      api.exchangeCodeForToken(
-        base,
-        redirectUri,
-        code,
-        app.client_id,
-        app.client_secret
-      ),
-    { base: instance.baseUrl, code },
-    (token: AccessTokenResponse): AppMessage => ({
-      type: "setAccessToken",
-      token,
-    })
-  );
-
-  return [{ type: "codeExchange", instance, app }, exchangeCommand];
+function hometimelinePageMessage(message: HomeTimelinePageMessage): AppMessage {
+  return { type: "home timeline page message", message };
 }
 
 class DimIceApp extends ElmishElement<AppModel, AppMessage> {
   initialize(): [AppModel, Command<AppMessage>] {
-    // Default instance for now
-    const defaultInstance = "mastodon.social";
+    // We delegate all of the authorization flow to the welcome page
+    // Therefore we need to always start there
+    const [pageModel, pageCommand] = welcomePage.initialize();
 
-    const instance: Instance = {
-      baseUrl: createInstanceBaseUrl(defaultInstance),
-    };
-
-    // Try load app credentials, if we don't have app credentials we need to start onboarding again
-    const app = tryLoadAppCredentials();
-    if (app === undefined)
-      return [
-        {
-          type: "firstOpen",
-          instance,
-        },
-        command.none,
-      ];
-
-    // Check if we are in authorization code flow
-    // This takes precedence before trying to load an existing access token in case the user wants to authorize with
-    // a different instance
-    if (location.pathname === "/redirect")
-      return startCodeExchange(instance, app);
-
-    // Try to load existing access token
-    const token = tryLoadAccessToken();
-    if (token === undefined)
-      return [
-        {
-          type: "authorization required",
-          app,
-          instance,
-        },
-        command.none,
-      ];
-
-    const verifyCredentialsCommand = command.ofMessage<AppMessage>({
-      type: "verify credentials",
-      accessToken: token.access_token,
-    });
+    const initialCommand: Command<AppMessage> = command.map(
+      welcomePageMessage,
+      pageCommand
+    );
 
     return [
-      { type: "verifying credentials", instance, app },
-      verifyCredentialsCommand,
-      // command.none,
+      {
+        activePage: { page: "welcome", model: pageModel },
+        instance: pageModel.instance,
+      },
+      initialCommand,
     ];
   }
 
@@ -222,220 +73,71 @@ class DimIceApp extends ElmishElement<AppModel, AppMessage> {
     message: AppMessage,
     model: AppModel
   ): [AppModel, Command<AppMessage>] {
-    //TODO split up in landing page and home page
     switch (message.type) {
-      case "set instance":
-        const instanceBaseUrl = createInstanceBaseUrl(message.instance);
-
-        // Yes this allocates a new object but I prefer immutability.
-        // Might consider changing when measurable disadvantage exists
-        return [
-          {
-            type: "firstOpen",
-            instance: { baseUrl: instanceBaseUrl },
-          },
-          command.none,
-        ];
-      case "create app":
-        // Create application on instance
-        const createAppCommand = command.ofPromise.perform(
-          () => api.createApp(model.instance.baseUrl, redirectUri),
-          undefined,
-          (app): AppMessage => ({ type: "set app credentials", app })
-        );
-        return [
-          { type: "creating app", instance: model.instance },
-          createAppCommand,
-        ];
-
-      // App credentials are set once during the onboarding flow
-      case "set app credentials":
-        // Save to local storage
-        const persistCredentialsCommand = command.ofFunction.perform(
-          saveAppCredentials,
-          message.app,
-          (): AppMessage => ({ type: "navigate to authorization page" })
-        );
-        console.debug({ model });
-        return [
-          { type: "codeExchange", app: message.app, instance: model.instance },
-          persistCredentialsCommand,
-        ];
-
-      // We can get here after an app has been created or an app already exists but reauthorization is required
-      case "navigate to authorization page":
-        if (!("app" in model)) {
-          console.error("Invalid state, expected to have app");
-          return [
-            { type: "firstOpen", instance: model.instance },
-            command.none,
-          ];
-        }
-        const authorizationUrl = createAuthorizationUrl(
-          model.instance.baseUrl,
-          model.app.client_id
-        );
-
-        console.debug("Navigating to authorization page", authorizationUrl);
-
-        // Could consider starting termination to gracefully shut down running processes but at this point there
-        // shouldn't be any
-        const navigateCommand = command.ofEffect<AppMessage>(() =>
-          globalThis.location.assign(authorizationUrl)
-        );
-        return [model, navigateCommand];
-
-      case "verify credentials":
-        if (!("app" in model)) {
-          console.error("Invalid state, expected to have app");
-          return [
-            { type: "firstOpen", instance: model.instance },
-            command.none,
-          ];
-        }
-
-        const verifyCommand = command.ofPromise.perform(
-          () =>
-            api.verifyCredentials(model.instance.baseUrl, message.accessToken),
-          undefined,
-          (result): AppMessage => {
-            if ("error" in result)
-              return { type: "navigate to authorization page" };
-
-            return { type: "load home timeline", token: message.accessToken };
-          }
-        );
-
-        return [
-          {
-            type: "verifying credentials",
-            app: model.app,
-            instance: model.instance,
-          },
-          verifyCommand,
-        ];
-
-      // Exchange credentials for access token
-      case "setAccessToken":
-        // Effect describes side effects which can be put into commands?
-        const persistTokenCommand = command.ofFunction.perform(
-          saveAccessToken,
-          message.token,
-          (): AppMessage => ({
-            type: "load home timeline",
-            token: message.token.access_token,
-          })
-        );
-
-        return [model, persistTokenCommand];
-      case "sign out":
-        if (model.type !== "homeTimeline") {
-          console.error("Can not sign out if not on home time line");
+      case "welcome page message":
+        if (model.activePage.page !== "welcome") {
+          console.error("Expected to be on welcome page");
           return [model, command.none];
         }
 
-        const revokeTokenCommand = command.ofEffect<AppMessage>(() =>
-          api.revokeToken(
-            model.instance.baseUrl,
-            model.accessToken,
-            model.app.client_id,
-            model.app.client_secret
-          )
+        const [welcomePageModel, welcomePageCommand, externalMessage] =
+          welcomePage.update(message.message, model.activePage.model);
+
+        const newCommands: Command<AppMessage> = command.map(
+          welcomePageMessage,
+          welcomePageCommand
         );
 
-        return [
-          { type: "firstOpen", instance: model.instance },
-          revokeTokenCommand,
-        ];
+        switch (externalMessage?.type) {
+          case undefined:
+            return [
+              {
+                instance: model.instance,
+                activePage: {
+                  page: "welcome",
+                  model: welcomePageModel,
+                },
+              },
+              newCommands,
+            ];
+          case "authorization completed":
+            const [newPageModel, newPageCommands] = homeTimelinePage.initialize(
+              externalMessage.accessToken,
+              externalMessage.instance
+            );
 
-      case "load home timeline":
-        if (!("app" in model)) {
-          console.error("Expected to have app at this point", { model });
-          return [model, command.none];
+            newCommands.push(
+              ...command.map(hometimelinePageMessage, newPageCommands)
+            );
+            return [
+              {
+                instance: externalMessage.instance,
+                activePage: { page: "home timeline", model: newPageModel },
+              },
+              newCommands,
+            ];
         }
-
-        //TODO error handling
-        const fetchTimelineCommand = command.ofPromise.perform(
-          () => api.getHomeTimeline(model.instance.baseUrl, message.token),
-          undefined,
-          (stati): AppMessage => ({ type: "set toots", homeTimeline: stati })
-        );
-        return [
-          {
-            type: "loadingTimeline",
-            accessToken: message.token,
-            app: model.app,
-            instance: model.instance,
-          },
-          fetchTimelineCommand,
-        ];
-
-      case "set toots":
-        //TODO this should change when we swap to home page with its own model
-        if (model.type !== "loadingTimeline") {
-          console.error("Can't set toots if wasn't loading them before");
-          return [model, command.none];
-        }
-
-        return [
-          {
-            type: "homeTimeline",
-            toots: message.homeTimeline.toots,
-            links: message.homeTimeline.links,
-            instance: model.instance,
-            isLoadingMoreToots: false,
-            accessToken: model.accessToken,
-            app: model.app,
-          },
-          command.none,
-        ];
       case "home timeline page message":
-        if (model.type != "homeTimeline") {
-          console.error("Excpected home time line model");
-          return [model, command.none];
-        }
-        const newModel = homeTimelinePage.update(message.message, model);
-        return [model, command.none];
-      case "virtualizer range changed":
-        if (model.type !== "homeTimeline") {
-          //TODO separate into home time line page component to avoid this invalid state
-          console.error("Separate state, claas");
+        if (model.activePage.page !== "home timeline") {
+          console.error("Expected to be on home timeline page");
           return [model, command.none];
         }
 
-        if (model.isLoadingMoreToots) {
-          // Already loading more toots don't need to start another one
-          return [model, command.none];
-        }
-
-        if (message.event.last !== model.toots.length - 1) {
-          return [model, command.none];
-        }
-
-        //TODO error handling
-        const fetchNextTootsCommand = command.ofPromise.perform(
-          () => api.fetchTootsFromUrl(model.links.next, model.accessToken),
-          undefined,
-          (toots): AppMessage => ({ type: "append toots", toots })
+        const [homePageModel, homePageCommand] = homeTimelinePage.update(
+          message.message,
+          model.activePage.model
         );
 
-        return [{ ...model, isLoadingMoreToots: true }, fetchNextTootsCommand];
-      case "append toots":
-        if (model.type !== "homeTimeline") {
-          //TODO separate into home time line page component to avoid this invalid state
-          console.error("Separate state again, claas");
-          return [model, command.none];
-        }
-
+        const mappedCommand = command.map(
+          hometimelinePageMessage,
+          homePageCommand
+        );
         return [
           {
-            ...model,
-            isLoadingMoreToots: false,
-            links: message.toots.links,
-            // I tried push but lit virtualizer does not seem to update if it is the same array
-            toots: [...model.toots, ...message.toots.toots],
+            activePage: { page: "home timeline", model: homePageModel },
+            instance: model.instance,
           },
-          command.none,
+          mappedCommand,
         ];
     }
   }
@@ -468,58 +170,15 @@ class DimIceApp extends ElmishElement<AppModel, AppMessage> {
 
   view(model: AppModel, dispatch: Dispatch<AppMessage>): TemplateResult {
     // Thanks to union support in TypeScript the compiler can detect that these are the only valid cases and that we don't need to handle default
-    switch (model.type) {
-      case "codeExchange":
-        //TODO improve this short lived UI to be more user friendly and less technical terms
-        return html`<section>Exchaning token...</section>`;
-
-      case "creating app":
-        return html`Creating App...`;
-      case "authorization required":
-        return html`<h1>Dim Ice</h1>
-          <form @submit=${dispatch({ type: "navigate to authorization page" })}>
-            <input
-              value="${model.instance.baseUrl.hostname}"
-              id="instance"
-              disabled
-            />
-            <button type="submit">Authorize</button>
-          </form>`;
-      case "firstOpen":
-        const errorNotification = createErrorUi(model.error);
-        // Using instance.hostname instead of host which would include the port (if specified)
-        // The assumption is that instances run on https default port 443 all the time
-        // This assumption should make selection of instance easier
-        return html`<h1>Dim Ice Create App</h1>
-          <form
-            @submit=${(event: SubmitEvent) => {
-              dispatch({ type: "create app" });
-              event.preventDefault();
-            }}
-          >
-            ${errorNotification}
-            <input
-              value="${model.instance.baseUrl.hostname}"
-              id="instance"
-              @change="${(event: Event) =>
-                dispatch({
-                  type: "set instance",
-                  instance: (event.target as HTMLInputElement).value,
-                })}"
-            />
-            <button type="submit">Authorize</button>
-          </form>`;
-
-      case "verifying credentials":
-        return html`Verifying credentials`;
-      case "loadingTimeline":
-        return html`<section>Loading toots...</section>`;
-      case "homeTimeline":
-        return html`<main>
-          ${homeTimelinePage.view(model, (message) =>
-            dispatch({ type: "home timeline page message", message })
-          )}
-        </main>`;
+    switch (model.activePage.page) {
+      case "welcome":
+        return welcomePage.view(model.activePage.model, (message) =>
+          dispatch(welcomePageMessage(message))
+        );
+      case "home timeline":
+        return homeTimelinePage.view(model.activePage.model, (message) =>
+          dispatch(hometimelinePageMessage(message))
+        );
     }
   }
 }

--- a/examples/dim-ice-app/instance.ts
+++ b/examples/dim-ice-app/instance.ts
@@ -1,0 +1,19 @@
+import Application from "./api/models/apps/application";
+
+/**
+ * Represents metadata about a mastodon server instance
+ */
+type Instance = {
+  baseUrl: URL;
+};
+
+/**
+ * Represents an instance where we have our app registered
+ */
+export type InstanceWithCredentials = {
+  //TODO think about adding scopes her
+  app: Application;
+  instance: Instance;
+};
+
+export default Instance;

--- a/examples/dim-ice-app/localStorage.ts
+++ b/examples/dim-ice-app/localStorage.ts
@@ -1,48 +1,56 @@
 import Application from "./api/models/apps/application";
 import AccessTokenResponse from "./api/models/oauth/accessTokenResponse";
+import Instance, { InstanceWithCredentials } from "./instance";
 
-const accessTokenStorageKey = "dim ice access token";
-export function tryLoadAccessToken(): AccessTokenResponse | undefined {
+function tryLoadAsJson<TValue>(key: string): TValue | undefined {
   //TODO better differentiate errrors
   // We don't have persistent storage in incognito windows
   if (!("localStorage" in window)) return undefined;
 
-  const value = localStorage.getItem(accessTokenStorageKey);
+  const value = localStorage.getItem(key);
   if (value === null) return undefined;
 
   //TODO error handling
-  return JSON.parse(value);
+  return JSON.parse(value) as TValue;
+}
+
+function saveAsJson<TValue>(key: string, value: TValue) {
+  //TODO better differentiate errrors
+  // We don't have persistent storage in incognito windows
+  if (!("localStorage" in window)) return;
+
+  const json = JSON.stringify(value);
+  localStorage.setItem(accessTokenStorageKey, json);
+}
+
+const accessTokenStorageKey = "dim ice access token";
+
+export function tryLoadAccessToken(): AccessTokenResponse | undefined {
+  return tryLoadAsJson(accessTokenStorageKey);
 }
 
 /**
  * Saves the access token to local storage
  */
 export function saveAccessToken(token: AccessTokenResponse) {
-  //TODO better differentiate errrors
-  // We don't have persistent storage in incognito windows
-  if (!("localStorage" in window)) return;
-
-  const value = JSON.stringify(token);
-  localStorage.setItem(accessTokenStorageKey, value);
+  saveAsJson(accessTokenStorageKey, token);
 }
+
 const appCredentialsStorageKey = "dim ice app credentials";
-export function tryLoadAppCredentials(): Application | undefined {
-  //TODO better differentiate errrors
-  // We don't have persistent storage in incognito windows
-  if (!("localStorage" in window)) return undefined;
 
-  const value = localStorage.getItem(appCredentialsStorageKey);
-  if (value === null) return undefined;
-
-  //TODO error handling
-  return JSON.parse(value) as Application;
+export function tryLoadAppCredentials(): InstanceWithCredentials | undefined {
+  return tryLoadAsJson(appCredentialsStorageKey);
 }
 
-export function saveAppCredentials(app: Application) {
-  //TODO better differentiate errrors
-  // We don't have persistent storage in incognito windows
-  if (!("localStorage" in window)) return;
-
-  const value = JSON.stringify(app);
-  localStorage.setItem(appCredentialsStorageKey, value);
+export function saveAppCredentials(app: InstanceWithCredentials) {
+  saveAsJson(appCredentialsStorageKey, app);
 }
+
+// const instanceStorageKey = "dim ice instance";
+// export function tryLoadInstance(): Instance | undefined {
+//   return tryLoadAsJson(instanceStorageKey);
+// }
+
+// export function saveInstance(instance: Instance) {
+//   saveAsJson(instanceStorageKey, instance);
+// }

--- a/examples/dim-ice-app/localStorage.ts
+++ b/examples/dim-ice-app/localStorage.ts
@@ -1,4 +1,3 @@
-import Application from "./api/models/apps/application";
 import AccessTokenResponse from "./api/models/oauth/accessTokenResponse";
 import { InstanceWithCredentials } from "./instance";
 
@@ -36,7 +35,7 @@ export function saveAccessToken(token: AccessTokenResponse) {
   saveAsJson(accessTokenStorageKey, token);
 }
 
-const appCredentialsStorageKey = "dim ice app credentials";
+const appCredentialsStorageKey = "dim ice instance app credentials";
 
 export function tryLoadAppCredentials(): InstanceWithCredentials | undefined {
   return tryLoadAsJson(appCredentialsStorageKey);

--- a/examples/dim-ice-app/localStorage.ts
+++ b/examples/dim-ice-app/localStorage.ts
@@ -1,9 +1,9 @@
 import Application from "./api/models/apps/application";
 import AccessTokenResponse from "./api/models/oauth/accessTokenResponse";
-import Instance, { InstanceWithCredentials } from "./instance";
+import { InstanceWithCredentials } from "./instance";
 
 function tryLoadAsJson<TValue>(key: string): TValue | undefined {
-  //TODO better differentiate errrors
+  //TODO better differentiate errors
   // We don't have persistent storage in incognito windows
   if (!("localStorage" in window)) return undefined;
 
@@ -15,12 +15,12 @@ function tryLoadAsJson<TValue>(key: string): TValue | undefined {
 }
 
 function saveAsJson<TValue>(key: string, value: TValue) {
-  //TODO better differentiate errrors
+  //TODO better differentiate errors
   // We don't have persistent storage in incognito windows
   if (!("localStorage" in window)) return;
 
   const json = JSON.stringify(value);
-  localStorage.setItem(accessTokenStorageKey, json);
+  localStorage.setItem(key, json);
 }
 
 const accessTokenStorageKey = "dim ice access token";
@@ -45,12 +45,3 @@ export function tryLoadAppCredentials(): InstanceWithCredentials | undefined {
 export function saveAppCredentials(app: InstanceWithCredentials) {
   saveAsJson(appCredentialsStorageKey, app);
 }
-
-// const instanceStorageKey = "dim ice instance";
-// export function tryLoadInstance(): Instance | undefined {
-//   return tryLoadAsJson(instanceStorageKey);
-// }
-
-// export function saveInstance(instance: Instance) {
-//   saveAsJson(instanceStorageKey, instance);
-// }

--- a/examples/dim-ice-app/pages/homeTimelinePage.ts
+++ b/examples/dim-ice-app/pages/homeTimelinePage.ts
@@ -1,0 +1,97 @@
+import { RangeChangedEvent } from "@lit-labs/virtualizer";
+import { TemplateResult, html } from "lit-html";
+import Status from "../api/models/status";
+import command, { Command, Dispatch } from "../../../src/elmish/command";
+import PaginationUrls from "../api/paginationUrls";
+import api from "../api/api";
+import { AccessToken } from "../api/models/string";
+import GetHomeTimelineResponse from "../api/models/getHomeTimelineResponse";
+
+export type HomeTimelinePageModel = {
+  readonly isLoadingMoreToots: boolean;
+  readonly toots: Status[];
+  readonly links: PaginationUrls;
+  readonly accessToken: AccessToken;
+};
+export type HomeTimelinePageMessage =
+  | {
+      type: "sign out";
+    }
+  // This occurs when the range of stati rendered to the dom is changed by the lit virtualizer. If we reach the end of
+  // the toots loaded, then we need to trigger loading more
+  | { type: "virtualizer range changed"; event: RangeChangedEvent }
+  | { type: "append toots"; response: GetHomeTimelineResponse };
+
+function initialize() {}
+
+function update(
+  message: HomeTimelinePageMessage,
+  model: HomeTimelinePageModel
+): [HomeTimelinePageModel, Command<HomeTimelinePageMessage>] {
+  switch (message.type) {
+    case "sign out":
+      return [model, command.none];
+
+    case "virtualizer range changed":
+      if (model.isLoadingMoreToots) {
+        // Already loading more toots don't need to start another one
+        return [model, command.none];
+      }
+
+      // Load more toots only when last toot has benn rendered
+      if (message.event.last !== model.toots.length - 1) {
+        return [model, command.none];
+      }
+
+      //TODO error handling
+      const fetchNextTootsCommand = command.ofPromise.perform(
+        () => api.fetchTootsFromUrl(model.links.next, model.accessToken),
+        undefined,
+        (response): HomeTimelinePageMessage => ({
+          type: "append toots",
+          response: response,
+        })
+      );
+
+      return [{ ...model, isLoadingMoreToots: true }, fetchNextTootsCommand];
+    case "append toots":
+      return [
+        {
+          ...model,
+          isLoadingMoreToots: false,
+          links: message.response.links,
+          // I tried push but lit virtualizer does not seem to update if it is the same array
+          toots: [...model.toots, ...message.response.toots],
+        },
+        command.none,
+      ];
+  }
+}
+function view(
+  model: HomeTimelinePageModel,
+  dispatch: Dispatch<HomeTimelinePageMessage>
+): TemplateResult {
+  return html` <header>
+    <h1>Home Timeline</h1>
+    <button @click=${() => dispatch({ type: "sign out" })}>Sign out</button>
+    <header>
+      <ul>
+        <lit-virtualizer
+          @rangeChanged=${(event: RangeChangedEvent) =>
+            dispatch({ type: "virtualizer range changed", event })}
+          .items=${model.toots}
+          .renderItem=${(status: Status) =>
+            html`<dim-ice-status-card .status=${status}></dim-ice-status-card>`}
+        >
+        </lit-virtualizer>
+      </ul>
+    </header>
+  </header>`;
+}
+
+const homeTimelinePage = {
+  update,
+  view,
+};
+
+export default homeTimelinePage;

--- a/examples/dim-ice-app/pages/homeTimelinePage.ts
+++ b/examples/dim-ice-app/pages/homeTimelinePage.ts
@@ -5,34 +5,89 @@ import command, { Command, Dispatch } from "../../../src/elmish/command";
 import PaginationUrls from "../api/paginationUrls";
 import api from "../api/api";
 import { AccessToken } from "../api/models/string";
-import GetHomeTimelineResponse from "../api/models/getHomeTimelineResponse";
+import Instance from "../instance";
 
-export type HomeTimelinePageModel = {
-  readonly isLoadingMoreToots: boolean;
-  readonly toots: Status[];
-  readonly links: PaginationUrls;
-  readonly accessToken: AccessToken;
-};
+export type HomeTimelinePageModel =
+  | { readonly type: "loading"; readonly accessToken: AccessToken }
+  | {
+      readonly type: "loaded";
+      readonly isLoadingMoreToots: boolean;
+      readonly toots: Status[];
+      readonly links: PaginationUrls;
+      readonly accessToken: AccessToken;
+    };
+
 export type HomeTimelinePageMessage =
+  | { type: "set toots"; toots: Status[]; links: PaginationUrls }
   | {
       type: "sign out";
     }
   // This occurs when the range of stati rendered to the dom is changed by the lit virtualizer. If we reach the end of
   // the toots loaded, then we need to trigger loading more
-  | { type: "virtualizer range changed"; event: RangeChangedEvent }
-  | { type: "append toots"; response: GetHomeTimelineResponse };
+  | { type: "virtualizer range changed"; event: RangeChangedEvent };
 
-function initialize() {}
+export type HomeTimelinePageExternalMessage = "sign out";
+function initialize(
+  accessToken: AccessToken,
+  instance: Instance
+): [HomeTimelinePageModel, Command<HomeTimelinePageMessage>] {
+  //TODO error handling
+  const fetchTimelineCommand = command.ofPromise.perform(
+    () => api.getHomeTimeline(instance.baseUrl, accessToken),
+    undefined,
+    ({ toots, links }): HomeTimelinePageMessage => ({
+      type: "set toots",
+      toots,
+      links,
+    })
+  );
+  return [{ type: "loading", accessToken }, fetchTimelineCommand];
+}
 
 function update(
   message: HomeTimelinePageMessage,
   model: HomeTimelinePageModel
-): [HomeTimelinePageModel, Command<HomeTimelinePageMessage>] {
+): [
+  HomeTimelinePageModel,
+  Command<HomeTimelinePageMessage>,
+  HomeTimelinePageExternalMessage?
+] {
   switch (message.type) {
     case "sign out":
-      return [model, command.none];
+      return [model, command.none, "sign out"];
+
+    // This currently handles the two cases of first load and additional toot loads
+    case "set toots":
+      if (model.type === "loading")
+        return [
+          {
+            type: "loaded",
+            accessToken: model.accessToken,
+            isLoadingMoreToots: false,
+            links: message.links,
+            toots: message.toots,
+          },
+          command.none,
+        ];
+
+      // I tried push but lit virtualizer does not seem to update if it is the same array
+      const newToots = [...model.toots, ...message.toots];
+
+      return [
+        {
+          ...model,
+          toots: newToots,
+          isLoadingMoreToots: false,
+        },
+        command.none,
+      ];
 
     case "virtualizer range changed":
+      if (model.type !== "loaded") {
+        console.error("Expected to be loaded");
+        return [model, command.none];
+      }
+
       if (model.isLoadingMoreToots) {
         // Already loading more toots don't need to start another one
         return [model, command.none];
@@ -47,49 +102,47 @@ function update(
       const fetchNextTootsCommand = command.ofPromise.perform(
         () => api.fetchTootsFromUrl(model.links.next, model.accessToken),
         undefined,
-        (response): HomeTimelinePageMessage => ({
-          type: "append toots",
-          response: response,
+        ({ links, toots }): HomeTimelinePageMessage => ({
+          type: "set toots",
+          links,
+          toots,
         })
       );
 
       return [{ ...model, isLoadingMoreToots: true }, fetchNextTootsCommand];
-    case "append toots":
-      return [
-        {
-          ...model,
-          isLoadingMoreToots: false,
-          links: message.response.links,
-          // I tried push but lit virtualizer does not seem to update if it is the same array
-          toots: [...model.toots, ...message.response.toots],
-        },
-        command.none,
-      ];
   }
 }
 function view(
   model: HomeTimelinePageModel,
   dispatch: Dispatch<HomeTimelinePageMessage>
 ): TemplateResult {
-  return html` <header>
-    <h1>Home Timeline</h1>
-    <button @click=${() => dispatch({ type: "sign out" })}>Sign out</button>
-    <header>
-      <ul>
-        <lit-virtualizer
-          @rangeChanged=${(event: RangeChangedEvent) =>
-            dispatch({ type: "virtualizer range changed", event })}
-          .items=${model.toots}
-          .renderItem=${(status: Status) =>
-            html`<dim-ice-status-card .status=${status}></dim-ice-status-card>`}
-        >
-        </lit-virtualizer>
-      </ul>
-    </header>
-  </header>`;
+  switch (model.type) {
+    case "loading":
+      return html`Loading toots...`;
+    case "loaded":
+      return html` <header>
+        <h1>Home Timeline</h1>
+        <button @click=${() => dispatch({ type: "sign out" })}>Sign out</button>
+        <header>
+          <ul>
+            <lit-virtualizer
+              @rangeChanged=${(event: RangeChangedEvent) =>
+                dispatch({ type: "virtualizer range changed", event })}
+              .items=${model.toots}
+              .renderItem=${(status: Status) =>
+                html`<dim-ice-status-card
+                  .status=${status}
+                ></dim-ice-status-card>`}
+            >
+            </lit-virtualizer>
+          </ul>
+        </header>
+      </header>`;
+  }
 }
 
 const homeTimelinePage = {
+  initialize,
   update,
   view,
 };

--- a/examples/dim-ice-app/pages/welcomePage.ts
+++ b/examples/dim-ice-app/pages/welcomePage.ts
@@ -1,0 +1,294 @@
+import { RangeChangedEvent } from "@lit-labs/virtualizer";
+import { TemplateResult, html, nothing } from "lit-html";
+import command, { Command, Dispatch } from "../../../src/elmish/command";
+import Application from "../api/models/apps/application";
+import AccessTokenResponse from "../api/models/oauth/accessTokenResponse";
+import Status from "../api/models/status";
+import { AccessToken } from "../api/models/string";
+import api from "../api/api";
+import { saveAccessToken, saveAppCredentials } from "../localStorage";
+import Instance, { InstanceWithCredentials } from "../instance";
+
+// Current location. Should not change while page is active
+// Redirect url needs to be registered with app creation
+const redirectUri = new URL("/redirect", location.href);
+
+export type WelcomePageMessage =
+  | {
+      readonly type: "set instance";
+      readonly instance: string;
+    }
+  | {
+      readonly type: "create app";
+    }
+  | {
+      readonly type: "set app credentials";
+      readonly app: Application;
+    }
+  | {
+      readonly type: "navigate to authorization page";
+    }
+  | {
+      // When the access token is loaded and needs to be verified
+      // If not valid then we need to reauthorize
+      readonly type: "verify credentials";
+      readonly accessToken: AccessToken;
+    }
+  | {
+      readonly type: "set access token";
+      readonly token: AccessTokenResponse;
+    }
+  | { readonly type: "navigate to home timeline" };
+
+/**
+ * Represents the errors that can occur. They are strings but can be complex objects if more information is required
+ */
+type AppError =
+  /**
+   * No code was provided when "/redirect" was opened. It should only be openend during an authorization code flow
+   * and the code should be set as query parameter
+   */
+  | "noCodeRedirect"
+  /**
+   * The browser does not support APIs that are required by the app. The app should try to work and not completely block users
+   * as it is very likely to still work even if incompatibility is detected. But the focus is to support modern browsers as of the time of writing.
+   */
+  | "outdatedBrowser";
+
+// These types use tagged unions to emulate unions from F# or other more functional programming languages
+type FirstOpen = {
+  readonly type: "first open";
+  readonly error?: AppError;
+  readonly instance: Instance;
+};
+
+type CreatingApp = {
+  readonly type: "creating app";
+};
+
+/**
+ * Represents the state when the app was openend after a redirect from the authorization code flow
+ */
+type RunningCodeExchange = {
+  readonly type: "running code exchange";
+} & InstanceWithCredentials;
+
+/**
+ * Represents the state when the user was signed in at one point so that we already have app credentials but the users
+ * access token is not valid (e.g. the token life time expired)
+ */
+type ReauthorizationRequired = {
+  readonly type: "authorization required";
+  readonly instance: Instance;
+} & InstanceWithCredentials;
+
+/**
+ * Represents the state the app is in after existing access token was loaded
+ */
+type VerifyingCredentials = {
+  readonly type: "verifying credentials";
+} & InstanceWithCredentials;
+
+export type WelcomePageModel = (
+  | FirstOpen
+  | CreatingApp
+  | ReauthorizationRequired
+  | RunningCodeExchange
+  | VerifyingCredentials
+) & { instance: Instance };
+
+function createInstanceBaseUrl(instance: string) {
+  //TODO we should add some verification here because the string can be anything
+  return new URL(`https://${instance}/`);
+}
+
+function createAuthorizationUrl(instanceBaseUrl: URL, clientId: string) {
+  const authorizationUrl = new URL("/oauth/authorize", instanceBaseUrl);
+  authorizationUrl.searchParams.set("client_id", clientId);
+  authorizationUrl.searchParams.set("scope", "read");
+  //TODO make redirect go to url opened by user
+  // When the user openes an url that they got send or saved as bookmark and are not signed in
+  // they will currently be redirected to the start page after the code exchange happened.
+  // They should instead be redirected to the link they originally opened
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri.toString());
+  authorizationUrl.searchParams.set("response_type", "code");
+
+  return authorizationUrl;
+}
+
+function update(
+  message: WelcomePageMessage,
+  model: WelcomePageModel
+): [WelcomePageModel, Command<WelcomePageMessage>] {
+  //   return [model, command.none];
+
+  switch (message.type) {
+    case "set instance":
+      const instanceBaseUrl = createInstanceBaseUrl(message.instance);
+      return [
+        { type: "first open", instance: { baseUrl: instanceBaseUrl } },
+        command.none,
+      ];
+
+    case "create app":
+      // Create application on instance
+      const createAppCommand = command.ofPromise.perform(
+        () => api.createApp(model.instance.baseUrl, redirectUri),
+        undefined,
+        (app): WelcomePageMessage => ({ type: "set app credentials", app })
+      );
+
+      return [
+        { type: "creating app", instance: model.instance },
+        createAppCommand,
+      ];
+
+    case "set app credentials":
+      // Save to local storage
+      const instanceWithCredentials: InstanceWithCredentials = {
+        instance: model.instance,
+        app: message.app,
+      };
+      const persistCredentialsCommand = command.ofFunction.perform(
+        saveAppCredentials,
+        instanceWithCredentials,
+        (): WelcomePageMessage => ({ type: "navigate to authorization page" })
+      );
+
+      return [
+        {
+          ...instanceWithCredentials,
+          type: "running code exchange",
+        },
+        persistCredentialsCommand,
+      ];
+
+    case "navigate to authorization page":
+      if (!("app" in model)) {
+        console.error("Invalid state, expected to have app");
+        //TODO possible endless loop here
+        return [
+          { type: "first open", instance: model.instance },
+          // Go back to step before
+          command.ofMessage<WelcomePageMessage>({ type: "create app" }),
+        ];
+      }
+
+      const authorizationUrl = createAuthorizationUrl(
+        model.instance.baseUrl,
+        model.app.client_id
+      );
+
+      // Could consider starting termination to gracefully shut down running processes but at this point there
+      // shouldn't be any
+      const navigateCommand = command.ofEffect<WelcomePageMessage>(() =>
+        globalThis.location.assign(authorizationUrl)
+      );
+      return [model, navigateCommand];
+
+    // This is the case when we loaded existing credentials
+    case "verify credentials":
+      const verifyCommand = command.ofPromise.perform(
+        () =>
+          api.verifyCredentials(model.instance.baseUrl, message.accessToken),
+        undefined,
+        (result): WelcomePageMessage => {
+          if ("error" in result)
+            return { type: "navigate to authorization page" };
+
+          return { type: "navigate to home timeline" };
+        }
+      );
+
+      return [model, verifyCommand];
+    case "set access token":
+      // Effect describes side effects which can be put into commands?
+      const persistTokenCommand = command.ofFunction.perform(
+        saveAccessToken,
+        message.token,
+        (): WelcomePageMessage => ({
+          type: "navigate to home timeline",
+        })
+      );
+
+      return [model, persistTokenCommand];
+    case "navigate to home timeline":
+      //TODO figure out how to send messages to parent like for navigation
+      return [model, command.none];
+  }
+}
+
+function createErrorUi(error?: AppError): TemplateResult | typeof nothing {
+  //TODO implement proper error ui
+  switch (error) {
+    case "noCodeRedirect":
+      return html`<section>
+        No code was provided for authorization code flow. If you tried to sign
+        in please go <a href="/">back</a> and try again
+      </section>`;
+
+    case "outdatedBrowser":
+      return html`<section>
+        Your browser might not be up to date or doesn't fully support this app.
+        Some features might not work as expected.
+      </section>`;
+
+    // In case we have no error
+    case undefined:
+      return nothing;
+  }
+}
+function view(
+  model: WelcomePageModel,
+  dispatch: Dispatch<WelcomePageMessage>
+): TemplateResult {
+  switch (model.type) {
+    case "first open":
+      const errorNotification = createErrorUi(model.error);
+      // Using instance.hostname instead of host which would include the port (if specified)
+      // The assumption is that instances run on https default port 443 all the time
+      // This assumption should make selection of instance easier
+      return html`<h1>Dim Ice Create App</h1>
+        <form
+          @submit=${(event: SubmitEvent) => {
+            dispatch({ type: "create app" });
+            event.preventDefault();
+          }}
+        >
+          ${errorNotification}
+          <input
+            value="${model.instance.baseUrl.hostname}"
+            id="instance"
+            @change="${(event: Event) =>
+              dispatch({
+                type: "set instance",
+                instance: (event.target as HTMLInputElement).value,
+              })}"
+          />
+          <button type="submit">Authorize</button>
+        </form>`;
+    case "creating app":
+      return html`Creating app...`;
+    case "authorization required":
+      return html`<h1>Dim Ice</h1>
+        <form @submit=${dispatch({ type: "navigate to authorization page" })}>
+          <input
+            value="${model.instance.baseUrl.hostname}"
+            id="instance"
+            disabled
+          />
+          <button type="submit">Authorize</button>
+        </form>`;
+    case "running code exchange":
+      return html`Exchaning code...`;
+    case "verifying credentials":
+      return html`Verifying credentials`;
+  }
+}
+
+const welcomePage = {
+  update,
+  view,
+};
+
+export default welcomePage;


### PR DESCRIPTION
With the new pages the welcome page handles all authorization and is hence required to be opened first. I will probably extract the authorization state later to exist in parallel to the page and app states and pass it to every page initialization to let the pages decide what to render or navigate away based on authorization state. Then the welcome page will only contain authorization logic (including app creation) for the first open and the credentials verification will be handled by the authorization state. This new authorization state should behave like a module component except that it has no view function. I will also consider renaming the welcome page to authorization page inside the code to better reflect the intended usage.